### PR TITLE
Fix: Ensure hourly activity chart displays in chronological order (#2)

### DIFF
--- a/static/js/charts.js
+++ b/static/js/charts.js
@@ -374,7 +374,8 @@ function createHourlyActivityChart(data) {
         return;
     }
 
-    const hourly = data.hourly;
+    // Sort by hour to ensure chronological order (0-23)
+    const hourly = [...data.hourly].sort((a, b) => a.hour - b.hour);
 
     // Extract data
     const labels = hourly.map(h => h.time_range);


### PR DESCRIPTION
## Summary
- Sort hourly data by hour field (0-23) before rendering the chart
- Ensures chronological display (00:00 → 23:00) even if API returns data in unexpected order

## Changes
- Modified `static/js/charts.js` - `createHourlyActivityChart()` function
- Added explicit sort: `const hourly = [...data.hourly].sort((a, b) => a.hour - b.hour);`

## Testing
- API test confirms data already returns in correct order:
  ```bash
  curl -s "http://localhost:4318/api/stats/hourly?date=2026-02-10" | jq '.hourly[] | {hour, time_range}'
  ```
- Browser test confirms Daily view shows Hourly Activity in 00:00→23:00 order

## Issue
Fixes #2

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)