### PR TITLE
Fix: Hide Cost Trend chart in Daily/Weekly views (#1, #4)

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -172,8 +172,15 @@ function renderMetricCards(data) {
 function renderCharts(data) {
     console.log('Rendering charts with data:', data);
 
-    // Create all charts
-    createCostTrendChart(data);
+    // Create charts based on period
+    // Cost Trend is only meaningful for monthly view
+    if (currentPeriod === 'monthly') {
+        createCostTrendChart(data);
+        showCostTrendChart();
+    } else {
+        hideCostTrendChart();
+    }
+
     createTokenPieChart(data);
     createModelBarChart(data);
     createToolBarChart(data);
@@ -256,6 +263,27 @@ function hideHourlyChart() {
 
     // Destroy chart instance if exists
     destroyChart('hourlyActivityChart');
+}
+
+/**
+ * Show cost trend chart container
+ */
+function showCostTrendChart() {
+    const container = document.getElementById('costTrendChart')?.closest('.chart-row');
+    if (container) {
+        container.style.display = 'block';
+    }
+}
+
+/**
+ * Hide cost trend chart container
+ */
+function hideCostTrendChart() {
+    const container = document.getElementById('costTrendChart')?.closest('.chart-row');
+    if (container) {
+        container.style.display = 'none';
+    }
+    destroyChart('costTrendChart');
 }
 
 // Initialize when DOM is ready

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -35,7 +35,7 @@
 </div>
 
 <!-- Cost Trend Chart (Full Width) -->
-<div class="chart-row full-width">
+<div class="chart-row full-width" id="cost-trend-row">
     <div class="chart-container">
         <canvas id="costTrendChart"></canvas>
     </div>


### PR DESCRIPTION
## Summary
- Modified `renderCharts()` in `dashboard.js` to show Cost Trend chart only in Monthly view
- Added `showCostTrendChart()` and `hideCostTrendChart()` helper functions for clean show/hide logic
- Added `id="cost-trend-row"` to dashboard.html for easier DOM targeting
- Cost Trend now displays only for Monthly period, hidden for Daily/Weekly views

## Implementation Details

### Changes to `static/js/dashboard.js`
1. Updated `renderCharts()` function to conditionally render Cost Trend:
   - Only calls `createCostTrendChart(data)` when `currentPeriod === 'monthly'`
   - Calls `showCostTrendChart()` to display the chart container
   - Calls `hideCostTrendChart()` for Daily/Weekly views

2. Added helper functions:
   - `showCostTrendChart()`: Shows the chart container by setting `display: block`
   - `hideCostTrendChart()`: Hides the chart container and destroys the Chart.js instance

### Changes to `templates/dashboard.html`
- Added `id="cost-trend-row"` to the Cost Trend chart container for easier targeting

## Test plan
- [x] Daily view: Cost Trend chart is hidden
- [x] Weekly view: Cost Trend chart is hidden
- [x] Monthly view: Cost Trend chart is visible and displays correctly
- [x] Switching between views updates chart visibility properly
- [x] No console errors when hiding/showing the chart

## Fixes
Closes #1, #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)