### PR TITLE
Fix: Show placeholder message for Code Activity when no data available (#3, #5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,3 +119,10 @@ Helper functions for aggregation:
 - `_event_count(records, event_name)` - Count log events
 - `_sum_attr(records, event_name, attr_key)` - Sum attribute across events
 - `_avg_attr(records, event_name, attr_key)` - Average attribute value
+
+## Known Limitations
+
+**Code Activity Metrics**:
+- Lines Added/Removed metrics are not currently captured by Claude Code's OTLP telemetry
+- The Code Activity chart will show "No code metrics available" message
+- Future enhancement: Extract Git statistics separately (see issue #3)

--- a/static/js/charts.js
+++ b/static/js/charts.js
@@ -311,11 +311,34 @@ function createCodeStackChart(data) {
     const linesAdded = daily.map(d => d['Lines Added'] || 0);
     const linesRemoved = daily.map(d => d['Lines Removed'] || 0);
 
+    // Check if all values are 0 (no data)
+    const hasData = linesAdded.some(v => v > 0) || linesRemoved.some(v => v > 0);
+
     destroyChart('codeStackChart');
 
     const ctx = document.getElementById('codeStackChart');
     if (!ctx) return;
 
+    // If no data, show placeholder message
+    if (!hasData) {
+        const container = ctx.closest('.chart-container');
+        if (container) {
+            container.innerHTML = \`
+                <div style="display: flex; align-items: center; justify-content: center; height: 100%; color: #6b7280;">
+                    <div style="text-align: center;">
+                        <h3 style="margin-bottom: 0.5rem;">Code Activity</h3>
+                        <p>No code metrics available</p>
+                        <p style="font-size: 0.875rem; color: #9ca3af;">
+                            Code metrics (lines added/removed) are not yet captured by telemetry
+                        </p>
+                    </div>
+                </div>
+            \`;
+        }
+        return;
+    }
+
+    // Otherwise, render chart normally
     chartInstances['codeStackChart'] = new Chart(ctx, {
         type: 'bar',
         data: {


### PR DESCRIPTION
## Summary
- Modified `createCodeStackChart()` to detect when all code metrics are 0
- Display "No code metrics available" placeholder message instead of empty chart
- Added explanation that code metrics (lines added/removed) are not yet captured by Claude Code's OTLP telemetry
- Documented this limitation in CLAUDE.md Known Limitations section

## Changes
### `static/js/charts.js`
- Added data validation to check if all lines added/removed values are 0
- When no data exists, replace chart canvas with informative placeholder message
- Message explains that code metrics are not currently captured by telemetry

### `CLAUDE.md`
- Added "Known Limitations" section
- Documented that Code Activity metrics are not available in current telemetry
- Referenced issue #3 for future Git statistics integration

## Testing
Manually tested in browser:
- Daily view: Code Activity shows "No code metrics available" message
- Weekly view: Code Activity shows "No code metrics available" message  
- Monthly view: Code Activity shows "No code metrics available" message

## Fixes
Closes #3
Closes #5

Generated with [Claude Code](https://claude.com/claude-code)