### PR TITLE
Fix: Truncate hourly activity chart at current hour for today's data

### DIFF
--- a/static/js/charts.js
+++ b/static/js/charts.js
@@ -323,7 +323,7 @@ function createCodeStackChart(data) {
     if (!hasData) {
         const container = ctx.closest('.chart-container');
         if (container) {
-            container.innerHTML = \`
+            container.innerHTML = `
                 <div style="display: flex; align-items: center; justify-content: center; height: 100%; color: #6b7280;">
                     <div style="text-align: center;">
                         <h3 style="margin-bottom: 0.5rem;">Code Activity</h3>
@@ -333,7 +333,7 @@ function createCodeStackChart(data) {
                         </p>
                     </div>
                 </div>
-            \`;
+            `;
         }
         return;
     }
@@ -398,7 +398,18 @@ function createHourlyActivityChart(data) {
     }
 
     // Sort by hour to ensure chronological order (0-23)
-    const hourly = [...data.hourly].sort((a, b) => a.hour - b.hour);
+    let hourly = [...data.hourly].sort((a, b) => a.hour - b.hour);
+
+    // For today's data, truncate future hours so current hour is at the right edge
+    const isToday = data.date === getToday();
+    if (isToday) {
+        const currentUtcHour = new Date().getUTCHours();
+        hourly = hourly.filter(h => h.hour <= currentUtcHour);
+        if (hourly.length === 0) {
+            console.warn('No hourly data available for current hours');
+            return;
+        }
+    }
 
     // Extract data
     const labels = hourly.map(h => h.time_range);

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -261,8 +261,10 @@ function hideHourlyChart() {
         chartRow.style.display = 'none';
     }
 
-    // Destroy chart instance if exists
-    destroyChart('hourlyActivityChart');
+    // Safely destroy chart if destroyChart function exists
+    if (typeof destroyChart !== 'undefined') {
+        destroyChart('hourlyActivityChart');
+    }
 }
 
 /**
@@ -283,7 +285,10 @@ function hideCostTrendChart() {
     if (container) {
         container.style.display = 'none';
     }
-    destroyChart('costTrendChart');
+    // Safely destroy chart if destroyChart function exists
+    if (typeof destroyChart !== 'undefined') {
+        destroyChart('costTrendChart');
+    }
 }
 
 // Initialize when DOM is ready

--- a/templates/base.html
+++ b/templates/base.html
@@ -48,7 +48,7 @@
     <!-- JavaScript -->
     <script src="/static/js/utils.js"></script>
     <script src="/static/js/api.js"></script>
-    <script src="/static/js/dashboard.js"></script>
     <script src="/static/js/charts.js"></script>
+    <script src="/static/js/dashboard.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- When viewing today's data, the Hourly Activity Pattern chart now ends at the current UTC hour instead of showing all 24 hours
- Past dates continue to display the full 24-hour range

Closes #10

## Test plan

- [ ] Open dashboard for today's date and verify the chart's right edge is the current hour
- [ ] Open dashboard for a past date and verify all 24 hours are displayed
- [ ] Verify the chart renders correctly when no hourly data exists yet (early morning UTC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)