### PR TITLE
feat: Per-model token breakdown with API pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ claude_usage/
 │   ├── aggregator.py           # 日次集計
 │   ├── sheets.py               # Google Sheets連携
 │   ├── analytics.py            # 複数日集計ロジック
+│   ├── pricing.py              # Anthropic API料金テーブル (https://docs.anthropic.com/en/docs/about-claude/pricing)
 │   ├── utils.py                # 日付ヘルパー
 │   └── api/                    # REST APIエンドポイント
 │       ├── stats.py            # 統計データAPI

--- a/src/pricing.py
+++ b/src/pricing.py
@@ -1,0 +1,66 @@
+"""Anthropic API pricing table and cost calculation.
+
+Pricing source: https://docs.anthropic.com/en/docs/about-claude/pricing
+Rates are per million tokens (MTok).
+"""
+
+# (input, output, cache_read, cache_write) per MTok in USD
+# Ordered longest-prefix-first for correct matching.
+PRICING: dict[str, tuple[float, float, float, float]] = {
+    "claude-opus-4-6":     (5.00,  25.00, 0.50,  6.25),
+    "claude-opus-4-5":     (5.00,  25.00, 0.50,  6.25),
+    "claude-opus-4-1":     (15.00, 75.00, 1.50,  18.75),
+    "claude-opus-4-":      (15.00, 75.00, 1.50,  18.75),
+    "claude-sonnet-4-5":   (3.00,  15.00, 0.30,  3.75),
+    "claude-sonnet-4-":    (3.00,  15.00, 0.30,  3.75),
+    "claude-sonnet-3-7":   (3.00,  15.00, 0.30,  3.75),
+    "claude-haiku-4-5":    (1.00,  5.00,  0.10,  1.25),
+    "claude-haiku-3-5":    (0.80,  4.00,  0.08,  1.00),
+    "claude-haiku-3":      (0.25,  1.25,  0.03,  0.30),
+}
+
+# Pre-sorted prefixes by length (longest first) for matching
+_SORTED_PREFIXES = sorted(PRICING.keys(), key=len, reverse=True)
+
+# Fallback pricing (Sonnet-class) for unknown models
+_FALLBACK = (3.00, 15.00, 0.30, 3.75)
+
+
+def get_pricing(model_id: str) -> tuple[float, float, float, float]:
+    """Return (input, output, cache_read, cache_write) per-MTok rates for a model.
+
+    Uses longest-prefix matching against the pricing table.
+    Falls back to Sonnet-class pricing for unknown models.
+    """
+    for prefix in _SORTED_PREFIXES:
+        if model_id.startswith(prefix):
+            return PRICING[prefix]
+    return _FALLBACK
+
+
+def calculate_cost(
+    model_id: str,
+    input_tokens: float,
+    output_tokens: float,
+    cache_read_tokens: float = 0,
+    cache_creation_tokens: float = 0,
+) -> float:
+    """Calculate USD cost for the given token counts.
+
+    Args:
+        model_id: Full model identifier (e.g. "claude-sonnet-4-5-20250929").
+        input_tokens: Number of input tokens.
+        output_tokens: Number of output tokens.
+        cache_read_tokens: Number of cache-read tokens.
+        cache_creation_tokens: Number of cache-creation (write) tokens.
+
+    Returns:
+        Cost in USD.
+    """
+    inp, out, cr, cw = get_pricing(model_id)
+    return (
+        input_tokens * inp / 1_000_000
+        + output_tokens * out / 1_000_000
+        + cache_read_tokens * cr / 1_000_000
+        + cache_creation_tokens * cw / 1_000_000
+    )

--- a/src/sheets.py
+++ b/src/sheets.py
@@ -88,6 +88,27 @@ def _check_duplicate(ws: gspread.Worksheet, target_date: str) -> bool:
     return target_date in dates
 
 
+def read_month_data(year: int, month: int) -> dict[str, dict]:
+    """Read daily rows for a given month from Google Sheets.
+
+    Returns:
+        Dict mapping date string (YYYY-MM-DD) to row data dict.
+    """
+    try:
+        ws = _get_sheet()
+        rows = ws.get_all_records()
+        prefix = f"{year}-{month:02d}"
+        result = {}
+        for row in rows:
+            d = str(row.get("Date", ""))
+            if d.startswith(prefix):
+                result[d] = dict(row)
+        return result
+    except Exception:
+        log.warning("Could not read from Google Sheets", exc_info=True)
+        return {}
+
+
 def append_row(summary: dict) -> None:
     """Append a daily summary row to Google Sheets."""
     ws = _get_sheet()

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -175,10 +175,13 @@ function renderCharts(data) {
     // Create charts based on period
     // Cost Trend is only meaningful for monthly view
     if (currentPeriod === 'monthly') {
+        showCostTrendChart();           // Show container first so Chart.js can compute dimensions
         createCostTrendChart(data);
-        showCostTrendChart();
+        showTokenTrendChart();
+        createTokenTrendChart(data);
     } else {
         hideCostTrendChart();
+        hideTokenTrendChart();
     }
 
     createTokenPieChart(data);
@@ -208,7 +211,7 @@ async function exportToCSV() {
             startDate = currentDate;
             const end = new Date(currentDate + 'T00:00:00');
             end.setDate(end.getDate() + 6);
-            endDate = end.toISOString().split('T')[0];
+            endDate = toLocalDateString(end);
         } else if (currentPeriod === 'monthly') {
             // currentDate is in YYYY-MM format for monthly
             const [year, month] = currentDate.split('-');
@@ -273,7 +276,30 @@ function hideHourlyChart() {
 function showCostTrendChart() {
     const container = document.getElementById('costTrendChart')?.closest('.chart-row');
     if (container) {
-        container.style.display = 'block';
+        container.style.display = '';  // Restore CSS default (grid)
+    }
+}
+
+/**
+ * Show token trend chart container
+ */
+function showTokenTrendChart() {
+    const container = document.getElementById('tokenTrendChart')?.closest('.chart-row');
+    if (container) {
+        container.style.display = '';
+    }
+}
+
+/**
+ * Hide token trend chart container
+ */
+function hideTokenTrendChart() {
+    const container = document.getElementById('tokenTrendChart')?.closest('.chart-row');
+    if (container) {
+        container.style.display = 'none';
+    }
+    if (typeof destroyChart !== 'undefined') {
+        destroyChart('tokenTrendChart');
     }
 }
 

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -40,12 +40,45 @@ function formatNumber(value, decimals = 0) {
 }
 
 /**
+ * Format a Date object as YYYY-MM-DD using local timezone
+ * @param {Date} d - Date object
+ * @returns {string} Date in YYYY-MM-DD format (local)
+ */
+function toLocalDateString(d) {
+    const year = d.getFullYear();
+    const month = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
+/**
+ * Convert a UTC hour to local hour for a given date
+ * @param {number} utcHour - Hour in UTC (0-23)
+ * @param {string} dateStr - Date in YYYY-MM-DD format
+ * @returns {{hour: number, timeRange: string}} Local hour and formatted time range
+ */
+function utcHourToLocal(utcHour, dateStr) {
+    // Use noon of the target date to get timezone offset (avoids DST boundary issues)
+    const noon = new Date(dateStr + 'T12:00:00');
+    const offsetMinutes = noon.getTimezoneOffset(); // negative for east of UTC
+    const offsetHours = -offsetMinutes / 60;
+
+    let localHour = utcHour + Math.round(offsetHours);
+    // Wrap around 0-23
+    localHour = ((localHour % 24) + 24) % 24;
+
+    const nextHour = (localHour + 1) % 24;
+    const timeRange = `${String(localHour).padStart(2, '0')}:00-${String(nextHour).padStart(2, '0')}:00`;
+
+    return { hour: localHour, timeRange };
+}
+
+/**
  * Get today's date in YYYY-MM-DD format
  * @returns {string} Today's date
  */
 function getToday() {
-    const today = new Date();
-    return today.toISOString().split('T')[0];
+    return toLocalDateString(new Date());
 }
 
 /**
@@ -54,11 +87,11 @@ function getToday() {
  * @returns {string} Monday's date in YYYY-MM-DD format
  */
 function getWeekStart(date) {
-    const d = typeof date === 'string' ? new Date(date + 'T00:00:00') : date;
+    const d = typeof date === 'string' ? new Date(date + 'T00:00:00') : new Date(date);
     const day = d.getDay();
     const diff = d.getDate() - day + (day === 0 ? -6 : 1); // Adjust when day is Sunday
-    const monday = new Date(d.setDate(diff));
-    return monday.toISOString().split('T')[0];
+    d.setDate(diff);
+    return toLocalDateString(d);
 }
 
 /**

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -41,6 +41,13 @@
     </div>
 </div>
 
+<!-- Token Trend Chart (Full Width, Monthly View Only) -->
+<div class="chart-row full-width" id="token-trend-row">
+    <div class="chart-container">
+        <canvas id="tokenTrendChart"></canvas>
+    </div>
+</div>
+
 <!-- Hourly Activity Chart (Full Width, Daily View Only) -->
 <div class="chart-row full-width" id="hourly-chart-row" style="display: none;">
     <div class="chart-container">


### PR DESCRIPTION
## Summary
- Add `src/pricing.py` with Anthropic API pricing table ([source](https://docs.anthropic.com/en/docs/about-claude/pricing)) and `calculate_cost()` for all Claude model families
- Aggregator now outputs `model_details` with per-model token counts and pricing-based cost calculation (replaces telemetry `cost_usd`)
- Token trend chart (monthly view) shows per-model stacked areas with detailed tooltip (input/output/cache breakdown + cost)
- Analytics merges `model_details` across days for weekly/monthly aggregate views
- Dashboard improvements: Google Sheets fallback for monthly view, UTC→local time conversion for hourly chart

## Test plan
- [ ] `uv run python -m src.aggregator --dry-run --date 2026-02-10` → confirm `model_details` in output
- [ ] Browser monthly view → per-model token trend chart with legend (e.g. "Sonnet 4.5")
- [ ] Hover tooltip shows In/Out/CR/CW breakdown + cost per model
- [ ] Cost trend chart reflects pricing-based total cost

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)